### PR TITLE
Continuous task queueing, naive prioritizing and thread count option

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "fluture": "^11.0.1",
     "ink": "2.3.0",
     "ink-spinner": "3.0.1",
+    "node-persist": "^3.0.5",
     "react": "16.8.6"
   },
   "devDependencies": {
     "@types/node": "13.7.0",
+    "@types/node-persist": "^3.0.0",
     "@types/yargs": "15.0.3",
     "typescript": "3.7.5"
   },

--- a/src/Executor.ts
+++ b/src/Executor.ts
@@ -3,7 +3,11 @@ import { Cancelable, CancelSignal, CancelError } from "@esfx/cancelable"
 import { FutureInstance as Future, attempt } from "fluture"
 
 export class AsyncExecutor implements Cancelable {
+  // The semaphore handles the work queue and the amount of running tasks
   private semaphore: AsyncSemaphore
+  // Waiters allows having async waiters outside the executor that
+  // check if a task should be queued or not
+  private waiters: Array<(value?: unknown) => void> = []
 
   constructor(capacity: number, private cancelToken: CancelSource) {
     this.semaphore = new AsyncSemaphore(capacity)
@@ -16,11 +20,54 @@ export class AsyncExecutor implements Cancelable {
       } catch (err) {
         reject(err)
       }
-      const cancel = task.finally(attempt(() => this.semaphore.release())).fork(reject, resolve)
+      const cancel = task
+        .finally(
+          attempt(() => {
+            this.semaphore.release()
+            this.resolveWaiter()
+          })
+        )
+        .fork(reject, resolve)
       CancelToken.from(this).subscribe(() => {
         cancel()
         reject(new CancelError("Operation was cancelled"))
       })
+    })
+  }
+
+  get isFull() {
+    return this.semaphore.count === 0
+  }
+
+  /**
+   * If executor isn't full, inform the waiter.
+   * If full, add to the waiter queue
+   */
+  private resolveOrWait(res: (value?: unknown) => void): void {
+    if (this.isFull) {
+      this.waiters.push(res)
+    } else {
+      res()
+    }
+  }
+  /**
+   * If executor has free space, inform the waiter
+   */
+  private resolveWaiter(): void {
+    if (!this.isFull) {
+      const res = this.waiters.shift()
+      if (res) {
+        res()
+      }
+    }
+  }
+
+  /**
+   * Wait for the executor to have free space for a new task
+   */
+  async wait() {
+    return new Promise(res => {
+      this.resolveOrWait(res)
     })
   }
 

--- a/src/commands/wsviz.ts
+++ b/src/commands/wsviz.ts
@@ -18,7 +18,7 @@ async function main() {
 
   process.stdout.write(`
 digraph dependencies {
-  ${Array.from(series)
+  ${flatten(Array.from(series))
     .map(
       (workspaces, i) =>
         `subgraph {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -34,9 +34,9 @@ export function toposort<T>(vertices: Array<T>, adjacent: (vertex: T) => Iterabl
 export function partition<T>(
   vertices: Array<T>,
   edges: (vertex: T) => Iterable<T>
-): Iterable<Set<T>> {
+): Array<[Set<T>, Set<T>]> {
   const remaining = new Set<T>(vertices)
-  const series: Array<Set<T>> = []
+  const series: Array<[Set<T>, Set<T>]> = []
 
   function satisfied(v: T) {
     for (const u of edges(v)) {
@@ -52,9 +52,9 @@ export function partition<T>(
   }
 
   // TODO: Detect cycles, otherwise we'll loop forever
-  const leaves = new Set<T>()
   while (remaining.size > 0) {
     const group = new Set<T>()
+    const leaves = new Set<T>()
     for (const v of remaining) {
       if (satisfied(v) && indeg(v) > 0) {
         group.add(v)
@@ -66,8 +66,7 @@ export function partition<T>(
     for (const v of group) {
       remaining.delete(v)
     }
-    series.push(group)
+    series.push([group, leaves])
   }
-  series.push(leaves)
   return series
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import assert from "assert"
+import { LocalStorage } from "node-persist"
 
 export function* range(from: number, to: number) {
   assert(from <= to, "from <= to")
@@ -12,4 +13,64 @@ export function repeat(n: number, fn: (i: number) => void) {
   for (const i of range(0, n - 1)) {
     fn(i)
   }
+}
+
+export async function calculateAveragesPerWorkspace(
+  workspaces: Workspace[],
+  storage: LocalStorage,
+  script: string
+) {
+  const averages = await Promise.all(
+    workspaces.map(async workspace => {
+      const times: number[] = (await storage.get(script + workspace.name)) || []
+      const average = times.reduce((sum, time) => sum + time, 0) / times.length
+      return {
+        workspace: workspace.name,
+        average
+      }
+    })
+  )
+  const averageTimePerWorkspace = averages.reduce<{
+    [key: string]: number
+  }>((acc, average) => {
+    return {
+      ...acc,
+      [average.workspace]: average.average
+    }
+  }, {})
+  return averageTimePerWorkspace
+}
+
+export function sort(
+  sortable: Array<Workspace>,
+  averageTimePerWorkspace: { [key: string]: number },
+  desc = true
+) {
+  return sortable.sort((a, b) => {
+    const aAverage = averageTimePerWorkspace[a.name]
+    const bAverage = averageTimePerWorkspace[b.name]
+    return desc ? bAverage - aAverage : aAverage - bAverage
+  })
+}
+
+export function sortGroupByAverageTime(
+  group: Set<Workspace>,
+  averageTimePerWorkspace: { [key: string]: number },
+  desc = true
+) {
+  return sort(Array(...group), averageTimePerWorkspace, desc)
+}
+
+export function sortGroupByAverageTimeDesc(
+  group: Set<Workspace>,
+  averageTimePerWorkspace: { [key: string]: number }
+) {
+  return sortGroupByAverageTime(group, averageTimePerWorkspace)
+}
+
+export function sortGroupByAverageTimeAsc(
+  group: Set<Workspace>,
+  averageTimePerWorkspace: { [key: string]: number }
+) {
+  return sortGroupByAverageTime(group, averageTimePerWorkspace, false)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,14 @@
     widest-line "^2.0.1"
     wrap-ansi "^4.0.0"
 
-"@types/node@13.7.0":
+"@types/node-persist@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node-persist/-/node-persist-3.0.0.tgz#a320e0abad6dd40b466bb88fcdafbfdf5eeb1358"
+  integrity sha512-kCeCaLJvPGVMB9gwFbf37k3e+MV/ZBjp3c7BepfTdggRU7Wdijbce+fIhcZmpnQw4o9PV8jGizGSz/vlbwikow==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@13.7.0":
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
   integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
@@ -628,10 +635,29 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+mkdirp@~0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
 ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+node-persist@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/node-persist/-/node-persist-3.0.5.tgz#ee6128df8e0f9ea45ea80090b8dd9dd338408900"
+  integrity sha512-zJmBA58kI9QAxXLMc4NLswgzXVIqKfsfQtiySMF6eEQ3kVvoM3YHzcP0//L9u30Fqx3cYe1FL/a+fyB3VwO/oQ==
+  dependencies:
+    mkdirp "~0.5.1"
 
 object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
I had some ideas of how to make the tool a bit more configurable and enable the user to affect how the tool runs stuff and see what works best for your project.

The original idea was to run leaves while blocking workspaces are still running if there are free resources in the pool.

I ended up doing a few changes, please check them out if you have time and suggest changes.

1. Run leaves run leaves while blocking workspaces are still running if there are free resources in the pool
2. By default, only `max / 2` threads are used. You can either use `-p` flag to enable previous default `max - 1` threads, or you can manually give the amount of threads to use with `-t`. There is no limit to how many threads you can give, but I can add it if you think it's a good idea.
3. Build order prioritizing with local cache. 
    - When running the tool with `-l` flag the tool persists the run times to disk per script. By running the tool multiple times the results are appended to the previous results. These persisted values are then used to prioritize the workspace order when running the scripts. 
    - Blocking workspaces are always run slowest first. 
    - By default, leaves are run fastest first while there are still blocking workspaces, but when all the blocking workspaces have been processed the remaining leaves are run slowest first. The idea is that we don't want the slow leaves to block running command in the blocking workspaces, so run the fastest ones first in the case the pool is full and blocking workspaces suddenly appear.
    - With the flag `-o` you can reverse the leaf order, so you can test which order works better in your case.

